### PR TITLE
[GLT-2789] Human-readable Run Aliases for ONT

### DIFF
--- a/dto/src/main/java/ca/on/oicr/gsi/runscanner/dto/OxfordNanoporeNotificationDto.java
+++ b/dto/src/main/java/ca/on/oicr/gsi/runscanner/dto/OxfordNanoporeNotificationDto.java
@@ -3,18 +3,18 @@ package ca.on.oicr.gsi.runscanner.dto;
 import ca.on.oicr.gsi.runscanner.dto.type.Platform;
 
 public class OxfordNanoporeNotificationDto extends NotificationDto {
-  private String scriptPurpose;
+  private String runType;
 
   @Override
   public Platform getPlatformType() {
     return Platform.OXFORDNANOPORE;
   }
 
-  public String getScriptPurpose() {
-    return scriptPurpose;
+  public String getRunType() {
+    return runType;
   }
 
-  public void setScriptPurpose(String newPurpose) {
-    scriptPurpose = newPurpose;
+  public void setRunType(String newType) {
+    runType = newType;
   }
 }

--- a/dto/src/main/java/ca/on/oicr/gsi/runscanner/dto/OxfordNanoporeNotificationDto.java
+++ b/dto/src/main/java/ca/on/oicr/gsi/runscanner/dto/OxfordNanoporeNotificationDto.java
@@ -3,8 +3,18 @@ package ca.on.oicr.gsi.runscanner.dto;
 import ca.on.oicr.gsi.runscanner.dto.type.Platform;
 
 public class OxfordNanoporeNotificationDto extends NotificationDto {
+  private String scriptPurpose;
+
   @Override
   public Platform getPlatformType() {
     return Platform.OXFORDNANOPORE;
+  }
+
+  public String getScriptPurpose() {
+    return scriptPurpose;
+  }
+
+  public void setScriptPurpose(String newPurpose) {
+    scriptPurpose = newPurpose;
   }
 }

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
@@ -23,6 +23,7 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
   protected static final String CONTEXT_TAGS = "UniqueGlobalKey/context_tags";
   protected final String SEQUENCER_NAME;
   protected static final int LANE_COUNT = 1;
+  protected final int PATH_OFFSET;
 
   protected static boolean isFileFast5(String fileName) {
     return fileName.endsWith(".fast5");
@@ -36,9 +37,10 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
     return isFileFast5(file.getFileName().toString());
   }
 
-  public BaseOxfordNanoporeProcessor(Builder builder, String seqName) {
+  public BaseOxfordNanoporeProcessor(Builder builder, String seqName, int offset) {
     super(builder);
     SEQUENCER_NAME = seqName;
+    PATH_OFFSET = offset;
   }
 
   @Override
@@ -112,7 +114,10 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
 
     OxfordNanoporeNotificationDto onnd = new OxfordNanoporeNotificationDto();
     IHDF5StringReader reader = HDF5FactoryProvider.get().openForReading(firstFile).string();
-    onnd.setRunAlias(reader.getAttr(TRACKING_ID, "run_id"));
+
+    Path path = firstFile.toPath();
+    onnd.setRunAlias(path.getName(PATH_OFFSET).toString());
+
     onnd.setSequencerFolderPath(runDirectory.toString());
     onnd.setSequencerName(SEQUENCER_NAME);
     onnd.setContainerSerialNumber(reader.getAttr(TRACKING_ID, "flow_cell_id"));

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
@@ -23,7 +23,6 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
   protected static final String CONTEXT_TAGS = "UniqueGlobalKey/context_tags";
   protected final String SEQUENCER_NAME;
   protected static final int LANE_COUNT = 1;
-  protected final int PATH_OFFSET;
 
   protected static boolean isFileFast5(String fileName) {
     return fileName.endsWith(".fast5");
@@ -37,10 +36,9 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
     return isFileFast5(file.getFileName().toString());
   }
 
-  public BaseOxfordNanoporeProcessor(Builder builder, String seqName, int offset) {
+  public BaseOxfordNanoporeProcessor(Builder builder, String seqName) {
     super(builder);
     SEQUENCER_NAME = seqName;
-    PATH_OFFSET = offset;
   }
 
   @Override
@@ -115,8 +113,8 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
     OxfordNanoporeNotificationDto onnd = new OxfordNanoporeNotificationDto();
     IHDF5StringReader reader = HDF5FactoryProvider.get().openForReading(firstFile).string();
 
-    Path path = firstFile.toPath();
-    onnd.setRunAlias(path.getName(PATH_OFFSET).toString());
+    Path p = runDirectory.toPath();
+    onnd.setRunAlias(p.getName(p.getNameCount() - 1).toString());
 
     onnd.setSequencerFolderPath(runDirectory.toString());
     onnd.setSequencerName(SEQUENCER_NAME);
@@ -130,6 +128,7 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
         reader.getAttr(TRACKING_ID, "version")
             + " + "
             + reader.getAttr(TRACKING_ID, "protocols_version"));
+    onnd.setScriptPurpose(reader.getAttr(TRACKING_ID, "exp_script_purpose"));
 
     additionalProcess(onnd, reader);
     return onnd;

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/MinionProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/MinionProcessor.java
@@ -9,7 +9,7 @@ import java.util.stream.Stream;
 
 public class MinionProcessor extends BaseOxfordNanoporeProcessor {
   public MinionProcessor(Builder builder, String seqName) {
-    super(builder, seqName, 5);
+    super(builder, seqName);
   }
 
   @Override

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/MinionProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/MinionProcessor.java
@@ -9,7 +9,7 @@ import java.util.stream.Stream;
 
 public class MinionProcessor extends BaseOxfordNanoporeProcessor {
   public MinionProcessor(Builder builder, String seqName) {
-    super(builder, seqName);
+    super(builder, seqName, 5);
   }
 
   @Override

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/PromethionProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/PromethionProcessor.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 public class PromethionProcessor extends BaseOxfordNanoporeProcessor {
 
   public PromethionProcessor(Builder builder, String seqName) {
-    super(builder, seqName, 4);
+    super(builder, seqName);
   }
 
   @Override
@@ -22,7 +22,7 @@ public class PromethionProcessor extends BaseOxfordNanoporeProcessor {
   @Override
   protected void additionalProcess(OxfordNanoporeNotificationDto onnd, IHDF5StringReader reader) {
     onnd.setSequencerPosition(reader.getAttr(TRACKING_ID, "device_id"));
-    onnd.setRunAlias(onnd.getRunAlias() + "@" + onnd.getSequencerPosition());
+    onnd.setRunAlias(onnd.getRunAlias() + "/" + onnd.getSequencerPosition());
   }
 
   public static RunProcessor create(Builder builder, ObjectNode jsonNodes) {

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/PromethionProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/PromethionProcessor.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 public class PromethionProcessor extends BaseOxfordNanoporeProcessor {
 
   public PromethionProcessor(Builder builder, String seqName) {
-    super(builder, seqName);
+    super(builder, seqName, 4);
   }
 
   @Override
@@ -22,6 +22,7 @@ public class PromethionProcessor extends BaseOxfordNanoporeProcessor {
   @Override
   protected void additionalProcess(OxfordNanoporeNotificationDto onnd, IHDF5StringReader reader) {
     onnd.setSequencerPosition(reader.getAttr(TRACKING_ID, "device_id"));
+    onnd.setRunAlias(onnd.getRunAlias() + "@" + onnd.getSequencerPosition());
   }
 
   public static RunProcessor create(Builder builder, ObjectNode jsonNodes) {


### PR DESCRIPTION
Change runAlias from the hash in the fast5 to the name of the run directory (in the case of the PromethION, append the sequencer position) for the sake of readability. 
Also track the exp_script_purpose from the fast5 for the sake of distinguishing sequencing and mux runs on the MinION.