### PR TITLE
Rename Main to ProcessRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you would like to scan for Illumina output, please see [runscanner-illumina/R
 ### Retrieving run output
 For troublesome runs, you can see the output for a particular run directory using:
 
-    java -cp $RUN_SCANNER_HOME/WEB-INF/classes:$RUN_SCANNER_HOME/WEB-INF/lib/'*' ca.on.oicr.gsi.runscanner.scanner.Main
+    java -cp $RUN_SCANNER_HOME/WEB-INF/classes:$RUN_SCANNER_HOME/WEB-INF/lib/'*' ca.on.oicr.gsi.runscanner.scanner.ProcessRun
 
 It will display instructions on how to use it. You will have to set the `RUN_SCANNER_HOME` to the path containing an unpacked version of the WAR.
 

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/ProcessRun.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/ProcessRun.java
@@ -19,12 +19,12 @@ import java.util.TimeZone;
  * Attempts to process run directories, provided on the command line, through a particular processor
  * and display the results. This is for debugging purposes.
  */
-public final class Main {
+public final class ProcessRun {
 
   public static void main(String[] args) throws IOException {
     if (args.length == 0) {
       System.err.println(
-          "Usage: java -DplatformType=ILLUMINA -Dname=default -Dtz=America/Toronto -Dparameters={} ca.on.oicr.gsi.runscanner.scanner.Main /path/to/run/folder");
+          "Usage: java -DplatformType=ILLUMINA -Dname=default -Dtz=America/Toronto -Dparameters={} ca.on.oicr.gsi.runscanner.scanner.ProcessRun /path/to/run/folder");
     }
     String platformName = System.getProperty("platformType");
     if (platformName == null) {


### PR DESCRIPTION
The existence of FindRuns makes the 'Main' name awkward.