### PR TITLE
Replace Setup Instructions w Link to Manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 This is a web service that monitors directories on the file system containing
 the output from sequencing instruments and serves metadata for runs.
 
+Full instructions for the setup and use of Run Scanner can be found in the [Run Scanner User Manual](https://miso-lims.github.io/runscanner/).
+
 ## Prerequisites
 
 * JDK 8
@@ -23,91 +25,7 @@ Extract the `.zip` or `.tar.gz` file.
 
 ## Setting Up Run Scanner
 
-In the below instructions, `${CATALINA_HOME}` is the directory where Tomcat is installed.
-`${CONTEXT}` is the context URL you wish to use for Run Scanner. This can be `ROOT` if you wish to
-deploy Run Scanner to the root context (e.g. www.myrunscanner.org) or something else to deploy to
-a subdirectory (e.g. 'runscanner' for www.myserver.org/runscanner/).
-
-Create a file called `${CONTEXT}.xml` in `${CATALINA_HOME}/conf/Catalina/localhost`, creating the directory if necessary, and populate it with the following information:
-
-    <Context>
-       <Parameter name="runscanner.configFile" value="/etc/runscanner.json" override="false"/>
-    </Context>
-
-In `/etc/runscanner.json`, or another path of your choosing, put JSON data describing your instruments. You will need one record for each instrument:
-
-    {
-      "path": "/some/directory/where/sequencer/writes",
-      "platformType": "ILLUMINA",
-      "name": "default",
-      "timeZone": "America/Toronto",
-      "parameters": {}
-    }
-
-The JSON file then contains a list of instruments:
-
-    [
-      {
-        "path": "/srv/sequencer/hiseq2500_1",
-        "platformType": "ILLUMINA",
-        "name": "default",
-        "timeZone": "America/Toronto",
-        "parameters": {}
-      },
-      {
-        "path": "/srv/sequencer/hiseq2500_2",
-        "platformType": "ILLUMINA",
-        "name": "default",
-        "timeZone": "America/Toronto",
-        "parameters": {}
-      },
-      {
-        "path": "/srv/sequencer/promethion",
-        "platformType": "OXFORDNANOPORE",
-        "name": "promethion",
-        "timeZone": "America/Toronto",
-        "parameters": {"name": "promethion_001"}
-      }
-    ]
-
-The name/platform-type combination decide what scanner is used to interpret the sequencer's results. A list of supported scanners can be found on the status page or the debugging interface.
-
-The parameters are set based on the processor.
-
-- PACBIO/default requires `address` to be set to the URL of the PacBio machine.
-- ILLUMINA/default optionally allows `checkOutput`. If true, the scanner will
-  try to look for BCL files to verify a run is complete if no logs are present.
-  If false, it will assume the run is complete if ambiguous. The default is true. This can be very slow on certain network file systems.
-- OXFORDNANOPORE processors require `name` to be set to either `minion` or `promethion` based on model. Additionally, a unique `name` for the sequencer must be specified in the `parameters`. 
-  
-<a id="building" />
-
-## Building Run Scanner
-
-Navigate to `$RUNSCANNER_SRC`.
-Build the application using:
-
-	mvn clean package
-	
-There will be an important build artefact: `scanner/target/scanner-$VERSION.war`
-
-<a id="illumina" />
-
-## Enabling Illumina scanning
-
-If you would like to scan for Illumina output, please see [runscanner-illumina/README.md](runscanner-illumina/README.md).
-
-<a id="release" />
-
-## Deploying
-
-1. Stop Run Scanner's Tomcat.
-1. Remove `${CATALINA_HOME}/webapps/${CONTEXT}` directory and `${CATALINA_HOME}/webapps/${CONTEXT}.war` file
-   (See note about `${CONTEXT}` in "Setting Up Run Scanner" above).
-1. Copy the `scanner-${VERSION}.war` from the build to `${CATALINA_HOME}/webapps/${CONTEXT}.war`.
-1. Start Run Scanner's Tomcat.
-
-<a id="debugging" />
+Please refer to [Installation & Setup](https://miso-lims.github.io/runscanner/pages/installation.html) in the Run Scanner User Manual for installation instructions.
 
 ## Debugging
 
@@ -124,3 +42,5 @@ To troubleshoot whether a processor can observe a run, you can see a list of all
     java -cp $RUN_SCANNER_HOME/WEB-INF/classes:$RUN_SCANNER_HOME/WEB-INF/lib/'*' ca.on.oicr.gsi.runscanner.scanner.FindRuns
     
 It will display usage instructions. You will have to set the `RUN_SCANNER_HOME` to the path containing an unpacked version of the WAR.
+
+Please refer to [Troubleshooting](https://miso-lims.github.io/runscanner/pages/troubleshooting.html) in the Run Scanner User Manual for more information.


### PR DESCRIPTION
Replacing instructions with link prevents possibility of desync between instruction sets, also lets users know the manual exists.