### PR TITLE
New Run Alias scheme for ONT

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -3,7 +3,8 @@
 Changes:
 
   * Added support for MinION output
-  * Add runscanner-mystery-files.log 
+  * Add runscanner-mystery-files.log
+  * Oxford Nanopore runs now contain all directory names between user-specified directory and fast5 location in run alias 
 
 # 1.5.0
 

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
@@ -214,7 +214,8 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
       log.debug("Selected read name " + read_name + " from " + firstFile);
 
       Path p = runDirectory.toPath();
-      onnd.setRunAlias(p.subpath(rootPath.getNameCount(), p.getNameCount()).toString());
+      onnd.setRunAlias(
+          p.subpath(rootPath.getNameCount(), p.getNameCount()).toString().replaceAll("/", "_"));
 
       onnd.setSequencerFolderPath(runDirectory.toString());
       onnd.setSequencerName(SEQUENCER_NAME);

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
@@ -29,6 +29,8 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
   /** Used for reporting non-fast5 files encountered while looking for fast5s */
   private final Logger mysteryFiles = LoggerFactory.getLogger("mysteryLogger");
 
+  private Path rootPath;
+
   protected static String trackingId;
   protected static String contextTags;
   protected final String SEQUENCER_NAME;
@@ -62,6 +64,7 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
 
   @Override
   public Stream<File> getRunsFromRoot(File root) {
+    rootPath = root.toPath();
     final List<File> runDirectories = new ArrayList<>();
     try {
       Files.walkFileTree(
@@ -211,8 +214,7 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
       log.debug("Selected read name " + read_name + " from " + firstFile);
 
       Path p = runDirectory.toPath();
-      // nameCount - 1 is the position of the name furthest from the root
-      onnd.setRunAlias(p.getName(p.getNameCount() - 1).toString());
+      onnd.setRunAlias(p.subpath(rootPath.getNameCount(), p.getNameCount()).toString());
 
       onnd.setSequencerFolderPath(runDirectory.toString());
       onnd.setSequencerName(SEQUENCER_NAME);
@@ -253,4 +255,8 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
   }
 
   protected abstract void additionalProcess(OxfordNanoporeNotificationDto nnd, IHDF5Reader reader);
+
+  public void setRootPath(Path newPath) {
+    rootPath = newPath;
+  }
 }

--- a/scanner/src/test/java/MinionProcessorTest.java
+++ b/scanner/src/test/java/MinionProcessorTest.java
@@ -18,6 +18,7 @@ public class MinionProcessorTest extends AbstractProcessorTest {
 
   @Override
   protected NotificationDto process(File directory) throws IOException {
+    instance.setRootPath(directory.toPath().getParent());
     return instance.process(directory, TimeZone.getTimeZone("America/Toronto"));
   }
 

--- a/scanner/src/test/java/PromethionProcessorTest.java
+++ b/scanner/src/test/java/PromethionProcessorTest.java
@@ -17,6 +17,7 @@ public class PromethionProcessorTest extends AbstractProcessorTest {
 
   @Override
   protected NotificationDto process(File directory) throws IOException {
+    instance.setRootPath(directory.toPath().getParent());
     return instance.process(directory, TimeZone.getTimeZone("America/Toronto"));
   }
 


### PR DESCRIPTION
Now uses all directory names between root and fast5 location. Track root
location in OxfordNanopore RunProcessor to accomodate this. Alter ONT
Sequencer tests because they never call getRunsFromRoot().