### PR TITLE
Changed links to relative links instead of absolute

### DIFF
--- a/.mkdocs.yml
+++ b/.mkdocs.yml
@@ -1,5 +1,11 @@
 site_name: Run Scanner
 theme: readthedocs
+site_url: https://miso-lims.github.io/runscanner/
+site_description: Run Scanner Documentation
+site_author: Genome Sequence Informatics, Ontario Institute for Cancer Research
+
+repo_url: https://github.com/miso-lims/runscanner
+
 nav:
     - About : index.md
     - Getting Started:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# Documentation for Run Scanner
+
+**Documentation: [https://runscanner.readthedocs.io](https://runscanner.readthedocs.io/en/latest/)**
+
+Run Scanner's documentation is built with [mkdocs](https://www.mkdocs.org/) 
+and hosted by [readthedocs](https://www.mkdocs.org/).
+
+
+
+## mkdocs prerequisites
+
+Install [mkdocs](https://www.mkdocs.org/#installation).
+
+
+## Test and deploy locally
+
+To test out changes locally, run:
+
+```
+mkdocs serve -f .mkdocs.yml
+```
+
+## Readthedocs configuration
+
+Configuration for readthedocs is located in 
+[../.readthedocs.yml](../.readthedocs.yml). It should build automatically. 
+Launch a build manually (or do other configuration by going to
+[https://readthedocs.org/projects/runscanner/](https://readthedocs.org/projects/runscanner/).
+
+## Code
+
+Run Scanner code is available from
+[https://github.com/miso-lims/runscanner](https://github.com/miso-lims/runscanner).
+
+## License
+
+Run Scanner is licensed under GPL-3.0. The license should be alongside the code,
+or available [here](https://github.com/miso-lims/runscanner/blob/master/LICENSE.md).

--- a/docs/illuminasetup.md
+++ b/docs/illuminasetup.md
@@ -19,7 +19,7 @@ Then:
     export CXX=$(which clang++-5.0 clang++) && ./build-illumina-interop && autoreconf -i && ./configure && make && sudo make install
 
 After which, deploy Run Scanner as directed in
-[Installation & Setup](/installation/)
+[Installation & Setup](../installation)
 
 <!-- All this should be moved to the Developer Documentation once we're at that point
 ## Developer Information

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -12,7 +12,7 @@ For Illumina support:
 
 Please ensure that your sequencer(s) are supported by Run Scanner.
 Please refer to 
-[Appendix C: Sequencers Supported by Run Scanner](/appendices/#appendix-c-sequencers-supported-by-run-scanner)
+[Appendix C: Sequencers Supported by Run Scanner](../appendices/#appendix-c-sequencers-supported-by-run-scanner)
  for more information.
 
 ### Downloading the latest release
@@ -62,9 +62,9 @@ list of instruments:
 
 The name/platformType combination is used to define how to interpret the
 sequencer's results. A full list of instrument options can be found in
-[Appendix A: Processor Definitions](/appendices/#appendix-a-processor-definitions) and a
+[Appendix A: Processor Definitions](../appendices/#appendix-a-processor-definitions) and a
 full list of supported sequencers can be found in
-[Appendix C: Sequencers Supported by Run Scanner](/appendices/#appendix-c-sequencers-supported-by-run-scanner).
+[Appendix C: Sequencers Supported by Run Scanner](../appendices/#appendix-c-sequencers-supported-by-run-scanner).
 
 ### Building Run Scanner
 
@@ -79,12 +79,12 @@ There will be an important build artefact:
 #### Enabling Illumina scanning
 
 If you would like to scan for Illumina output, please follow
-[Illumina Setup](/illuminasetup/) before deploying.
+[Illumina Setup](../illuminasetup/) before deploying.
 
 ### Deploying
 
 1. Stop Run Scanner's Tomcat.
 1. Remove `${CATALINA_HOME}/webapps/${CONTEXT}` directory and `${CATALINA_HOME}/webapps/${CONTEXT}.war` file
-   (See note about `${CONTEXT}` in [Setting Up Run Scanner](/installation/#setting-up-run-scanner) above).
+   (See note about `${CONTEXT}` in [Setting Up Run Scanner](../installation/#setting-up-run-scanner) above).
 1. Copy the `scanner-${VERSION}.war` from the build to `${CATALINA_HOME}/webapps/${CONTEXT}.war`.
 1. Start Run Scanner's Tomcat.

--- a/docs/main.md
+++ b/docs/main.md
@@ -27,7 +27,7 @@ tasks by Run Scanner. Run Scanner will continue processing runs after scanning
 Underneath the [Core](#core) section, Run Scanner displays one
 section per sequencing output directory, as defined in the configuration
 JSON (for more information, please refer to
-[Setting Up Run Scanner](/installation/#setting-up-run-scanner)). Each section
+[Setting Up Run Scanner](../installation/#setting-up-run-scanner)). Each section
 is headed by the directory path, and outlines the platform, processor type,
 and time zone defined in the JSON file.
 
@@ -38,10 +38,10 @@ facing in accessing the directory. The issue may be that the target of the
 provided path does not exist, or that Run Scanner does not have the necessary
  permissions to read or write to the directory. For more information, please
 refer to
-[Sequencing Output Directory 'Valid?' reads 'No'](/troubleshooting/#sequencing-output-directory-valid-reads-no).
+[Sequencing Output Directory 'Valid?' reads 'No'](../troubleshooting/#sequencing-output-directory-valid-reads-no).
 
 ### Processors
 The final section of the Main Page is a list of available name and
 platformType combinations. This section can be considered a reference for
 creating the configuration JSON (as outlined in
-[Setting Up Run Scanner](/installation/#setting-up-run-scanner)).
+[Setting Up Run Scanner](../installation/#setting-up-run-scanner)).

--- a/docs/processing.md
+++ b/docs/processing.md
@@ -3,7 +3,7 @@ The Processing page of Run Scanner can be accessed by clicking the
 'Processing' link on the header bar of the Run Scanner interface. This page
 outlines the runs which have been detected by Run Scanner and are currently
 being processed by Run Scanner. Items will be removed from the list and into
-[Scanned](/scanned/) as they are successfully processed.
+[Scanned](../scanned/) as they are successfully processed.
 
 Each item in the list contains the Run Alias of the detected run, and the
 path at which the run was found.

--- a/docs/scanned.md
+++ b/docs/scanned.md
@@ -17,11 +17,11 @@ from the sequencing run output.
 
 This file contains the same information which will be returned when accessed
 via the REST API.
-<!-- right? --> <!-- For more information, please refer to [API Docs](/api/). -->
+<!-- right? --> <!-- For more information, please refer to [API Docs](../api/). -->
 
 The fields within this file vary based on the model of sequencer which has
 produced the run. (For more information, please refer to
- [Appendix B: Run JSON Fields](/appendices/#appendix-b-run-json-fields))
+ [Appendix B: Run JSON Fields](../appendices/#appendix-b-run-json-fields))
 
 All major web browsers should support viewing JSON files interactively,
 <!-- right? --> however these files can also be opened in a text editor or

--- a/docs/scheduled.md
+++ b/docs/scheduled.md
@@ -3,8 +3,8 @@ The Scheduled page of Run Scanner can be accessed by clicking the 'Scheduled'
  link on the header bar of the Run Scanner interface. This page outlines the
 runs which have been detected by Run Scanner but have not yet been processed.
 Items will be removed from the list and into
-[Processing](/processing/) and then
-[Scanned](/scanned/) as they are successfully processed
+[Processing](../processing/) and then
+[Scanned](../scanned/) as they are successfully processed
 by Run Scanner.
 
 Each item in the list contains the Run Alias of the detected run, and the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -29,7 +29,7 @@ and execute permissions on said directory. The processor in the configuration
  JSON must also be specified correctly, and be provided a valid time zone.
 
 For more information on the configuration JSON file, please refer to
-[Setting Up Run Scanner](/installation/#setting-up-run-scanner).
+[Setting Up Run Scanner](../installation/#setting-up-run-scanner).
 
 <!-- TODO: These messages really could be more user-friendly in Run Scanner itself -->
 #### 'Path is null!'
@@ -61,8 +61,8 @@ contents.
 This message appears if Run Scanner cannot construct a Processor given the
 information specified in the configuration JSON. Ensure that the 'name',
 'platformType', and 'parameters' fields are filled out appropriately as per
-[Setting Up Run Scanner](/installation/#setting-up-run-scanner) and
-[Appendix A: Processor Definitions](/appendices/#appendix-a-processor-definitions).
+[Setting Up Run Scanner](../installation/#setting-up-run-scanner) and
+[Appendix A: Processor Definitions](../appendices/#appendix-a-processor-definitions).
 
 #### 'TimeZone is null!'
 This message appears if the 'timeZone' field in the configuration JSON is
@@ -82,7 +82,7 @@ blank or invalid. This field uses TZ Database names. Please refer to
     Run Scanner expects run data to be in certain formats per sequencer.
     Please ensure your sequencer is supported and running a supported software
     version. Please refer to 
-    [Appendix C: Sequencers Supported by Run Scanner](/appendices/#appendix-c-sequencers-supported-by-run-scanner)
+    [Appendix C: Sequencers Supported by Run Scanner](../appendices/#appendix-c-sequencers-supported-by-run-scanner)
     for more information.
 
 It is also possible that the run data contains invalid information. Try
@@ -98,5 +98,5 @@ sequencing output directory. Grant these permissions if necessary.
 #### Ensure runscanner-illumina is installed
 If runs from an Illumina sequencer are universally failing, ensure that
 runscanner-illumina is installed correctly, as outlined in
-[Illumina Setup](/illuminasetup/). Illumina runs
+[Illumina Setup](../illuminasetup/). Illumina runs
 cannot be read without this interoperability application.

--- a/docs/unreadable.md
+++ b/docs/unreadable.md
@@ -14,9 +14,9 @@ These runs may have failed due to:
 Runs will **not** appear in the Unreadable list if they are within a
 sequencing output directory for which Run Scanner lacks permission to
 access entirely. The 
-[Sequencing Output Directories section of the Main Page](/main/#sequencing-output-directories)
+[Sequencing Output Directories section of the Main Page](../main/#sequencing-output-directories)
 will indicate when this is the
 case.
 
 For more information on fixing runs which have failed to read, please
-refer to [Troubleshooting unreadable runs](/troubleshooting/#runs-appear-in-unreadable-list).
+refer to [Troubleshooting unreadable runs](../troubleshooting/#runs-appear-in-unreadable-list).


### PR DESCRIPTION
Absolute links don't work with version numbers in readthedocs

Update: also added a README and updated the config file to have the URL 