### PR TITLE
Try new attribute name, try again with old name

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,15 @@
+# Unreleased
+
+Changes:
+
+  * Fix version incompatibility which made PromethION runs Unreadable
+
+# 1.8.0
+
+Changes:
+
+  * Export length of all reads in Illumina runs
+
 # 1.7.0
 
 Changes:

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <skipIllumina>true</skipIllumina>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.9.10</jackson.version>
     <spring.version>5.1.7.RELEASE</spring.version>
   </properties>
   <dependencyManagement>

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
@@ -222,19 +222,24 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
       trackingId = read_name + "/tracking_id";
       contextTags = read_name + "/context_tags";
 
-      onnd.setContainerSerialNumber(genericReader.string().getAttr(trackingId, "flow_cell_id"));
+      if (genericReader.hasAttribute(trackingId, "flow_cell_id"))
+        onnd.setContainerSerialNumber(genericReader.string().getAttr(trackingId, "flow_cell_id"));
 
       onnd.setLaneCount(LANE_COUNT);
       onnd.setHealthType(HealthType.UNKNOWN);
 
-      onnd.setStartDate(
-          ZonedDateTime.parse(genericReader.string().getAttr(trackingId, "exp_start_time"))
-              .toInstant());
+      if (genericReader.hasAttribute(trackingId, "exp_start_time"))
+        onnd.setStartDate(
+            ZonedDateTime.parse(genericReader.string().getAttr(trackingId, "exp_start_time"))
+                .toInstant());
 
-      onnd.setSoftware(genericReader.string().getAttr(trackingId, "version"));
-      onnd.setProtocolVersion(genericReader.string().getAttr(trackingId, "protocols_version"));
+      if (genericReader.hasAttribute(trackingId, "version"))
+        onnd.setSoftware(genericReader.string().getAttr(trackingId, "version"));
+      if (genericReader.hasAttribute(trackingId, "protocols_version"))
+        onnd.setProtocolVersion(genericReader.string().getAttr(trackingId, "protocols_version"));
 
-      onnd.setRunType(genericReader.string().getAttr(trackingId, "exp_script_purpose"));
+      if (genericReader.hasAttribute(trackingId, "exp_script_purpose"))
+        onnd.setRunType(genericReader.string().getAttr(trackingId, "exp_script_purpose"));
 
       additionalProcess(onnd, genericReader);
       return onnd;

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/MinionProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/MinionProcessor.java
@@ -45,7 +45,8 @@ public class MinionProcessor extends BaseOxfordNanoporeProcessor {
 
   @Override
   protected void additionalProcess(OxfordNanoporeNotificationDto onnd, IHDF5Reader reader) {
-    onnd.setContainerModel(reader.string().getAttr(contextTags, "sequencing_kit"));
+    if (reader.hasAttribute(contextTags, "sequencing_kit"))
+      onnd.setContainerModel(reader.string().getAttr(contextTags, "sequencing_kit"));
   }
 
   public static RunProcessor create(Builder builder, ObjectNode jsonNodes) {

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/PromethionProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/PromethionProcessor.java
@@ -5,7 +5,6 @@ import ch.systemsx.cisd.hdf5.IHDF5Reader;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.nio.file.Path;
 import java.util.stream.Stream;
-import ncsa.hdf.hdf5lib.exceptions.HDF5AttributeException;
 
 public class PromethionProcessor extends BaseOxfordNanoporeProcessor {
 
@@ -33,11 +32,10 @@ public class PromethionProcessor extends BaseOxfordNanoporeProcessor {
   @Override
   protected void additionalProcess(OxfordNanoporeNotificationDto onnd, IHDF5Reader reader) {
     onnd.setSequencerPosition(reader.string().getAttr(trackingId, "device_id"));
-    try {
+    if (reader.hasAttribute(contextTags, "flow_cell_product_code")) {
       onnd.setContainerModel(reader.string().getAttr(contextTags, "flow_cell_product_code"));
-    } catch (HDF5AttributeException h5ae) {
+    } else if (reader.hasAttribute(contextTags, "flowcell_type")) {
       onnd.setContainerModel(reader.string().getAttr(contextTags, "flowcell_type"));
-      // Will throw again, causing failed read & trace in log, if neither works
     }
   }
 

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/PromethionProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/PromethionProcessor.java
@@ -31,7 +31,9 @@ public class PromethionProcessor extends BaseOxfordNanoporeProcessor {
 
   @Override
   protected void additionalProcess(OxfordNanoporeNotificationDto onnd, IHDF5Reader reader) {
-    onnd.setSequencerPosition(reader.string().getAttr(trackingId, "device_id"));
+    if (reader.hasAttribute(trackingId, "device_id"))
+      onnd.setSequencerPosition(reader.string().getAttr(trackingId, "device_id"));
+
     if (reader.hasAttribute(contextTags, "flow_cell_product_code")) {
       onnd.setContainerModel(reader.string().getAttr(contextTags, "flow_cell_product_code"));
     } else if (reader.hasAttribute(contextTags, "flowcell_type")) {

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/PromethionProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/PromethionProcessor.java
@@ -5,6 +5,7 @@ import ch.systemsx.cisd.hdf5.IHDF5Reader;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.nio.file.Path;
 import java.util.stream.Stream;
+import ncsa.hdf.hdf5lib.exceptions.HDF5AttributeException;
 
 public class PromethionProcessor extends BaseOxfordNanoporeProcessor {
 
@@ -32,7 +33,12 @@ public class PromethionProcessor extends BaseOxfordNanoporeProcessor {
   @Override
   protected void additionalProcess(OxfordNanoporeNotificationDto onnd, IHDF5Reader reader) {
     onnd.setSequencerPosition(reader.string().getAttr(trackingId, "device_id"));
-    onnd.setContainerModel(reader.string().getAttr(contextTags, "flowcell_type"));
+    try {
+      onnd.setContainerModel(reader.string().getAttr(contextTags, "flow_cell_product_code"));
+    } catch (HDF5AttributeException h5ae) {
+      onnd.setContainerModel(reader.string().getAttr(contextTags, "flowcell_type"));
+      // Will throw again, causing failed read & trace in log, if neither works
+    }
   }
 
   public static RunProcessor create(Builder builder, ObjectNode jsonNodes) {


### PR DESCRIPTION
Fixes GLT-3002. 'Unreadable' & stack trace when neither attribute is found maintains old behaviour