### PR TITLE
Fix issues with Nanopore run processing

### DIFF
--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/BaseOxfordNanoporeProcessor.java
@@ -263,7 +263,7 @@ public abstract class BaseOxfordNanoporeProcessor extends RunProcessor {
       final Optional<File> summaryFile = Stream.of(Objects.requireNonNull(runDirectory.listFiles()))
               .filter(f -> f.getName().matches("final_summary.*\\.txt"))
               .findFirst();
-      if (summaryFile.isPresent() && summaryFile.get().exists()) {
+      if (summaryFile.isPresent()) {
         final Properties summary = new Properties();
         try (final InputStream summaryInput = new FileInputStream(summaryFile.get())) {
           summary.load(summaryInput);


### PR DESCRIPTION
- Fixes NullPointerException when running ProcessRun on Nanopore run.
- Fixes runscanner not finding `sequencing_summary.txt` files for completed runs by trying to find `sequencing_summary*.txt` files created by minknow-nc 19.12.5 and above for Nanopore MinION using `listFiles` and regex pattern (e.g. `sequencing_summary_FAN02662_19282c29.txt`). It should still be compatible with old style `sequencing_summary.txt` files. Works with GridION runs as well.