### PR TITLE
Update dependencies

### DIFF
--- a/dto/pom.xml
+++ b/dto/pom.xml
@@ -34,9 +34,5 @@
       <artifactId>hamcrest-core</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>cisd</groupId>
-      <artifactId>jhdf5</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <skipIllumina>true</skipIllumina>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <jackson.version>2.10.0</jackson.version>
+    <jackson.version>2.12.2</jackson.version>
     <spring.version>5.2.3.RELEASE</spring.version>
   </properties>
   <dependencyManagement>

--- a/scanner/pom.xml
+++ b/scanner/pom.xml
@@ -60,6 +60,11 @@
         <groupId>io.springfox</groupId>
         <artifactId>springfox-swagger-ui</artifactId>
       </dependency>
+      <dependency>
+        <groupId>cisd</groupId>
+        <artifactId>jhdf5</artifactId>
+      </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
Move HDF5 dependency to sever from DTOs since DTOs do not use it directly.
Also, update to latest Jackson version.