### PR TITLE
removed guava dependency

### DIFF
--- a/scanner/pom.xml
+++ b/scanner/pom.xml
@@ -100,11 +100,6 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-webmvc</artifactId>
     </dependency>
-    <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>22.0</version>
-      </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>


### PR DESCRIPTION
There are dependabot alerts for vulnerabilities in this version of Guava, but apparently we're not even using it anyway