### PR TITLE
added note about locale to install guide

### DIFF
--- a/docs/illuminasetup.md
+++ b/docs/illuminasetup.md
@@ -10,6 +10,10 @@ On Fedora/Red Hat:
     sudo yum groupinstall "Development Tools"
     sudo yum install pkgconfig cmake jsoncpp-devel libtool autoconf clang
 
+Note: Some metrics will be formatted based on the machine's locale preferences,
+so you may want to check those via the `locale` command (on most systems).
+
+
 Pull the Illumina Interop code via:
 
     git submodule init && git submodule update


### PR DESCRIPTION
JIRA Ticket: n/a

- [ ] Updates release notes (n/a)
- [x] Updates developer documentation

It turned out this was the reason for many of our runs getting updated with the switchover to new a Run Scanner. The new machine has a different locale, and removed the thousands-separator from a couple metrics (clusters and clusters pf). This only shows up in a table on the MISO run page and is unlikely to bother anyone, so we're leaving as is instead of causing another mass update