### PR TITLE
GLT-3870 Added gauge metric to track if run directory is readable or not

### DIFF
--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/Scheduler.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/Scheduler.java
@@ -239,8 +239,8 @@ public class Scheduler {
           .register();
   private static final Gauge lastScanStartTime =
       Gauge.build()
-          .name("miso_runscanner_last_scan_start_time_seconds.")
-          .help("start time of last scan")
+          .name("miso_runscanner_last_scan_start_time_seconds")
+          .help("start time of last scan.")
           .register();
 
   private static final Gauge loadingRunDirectoryValid =
@@ -361,7 +361,7 @@ public class Scheduler {
   /**
    * Determine if a run directory is in need of processing.
    *
-   * <p>This means that is is not in a processing queue, failed processing last time, nor needs
+   * <p>This means that it is not in a processing queue, failed processing last time, nor needs
    * reprocessing (for runs still active on the sequencer)
    */
   private boolean isUnprocessed(File directory) {


### PR DESCRIPTION
JIRA Ticket: https://jira.oicr.on.ca/browse/GLT-3870

- Add a gauge metric to track run directory status if readable or not
- 0 represents run directory is unreadable (i.e. the directory doesn't exist, can't be read, or can't execute)
- 1 represents the run directory is readable (i.e the directory exists, can be read, and can execute)

