### PR TITLE
[GP-4550] Update actions to v4

### DIFF
--- a/.github/workflows/run_scanner_ci.yml
+++ b/.github/workflows/run_scanner_ci.yml
@@ -4,13 +4,13 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt'
       - name: Cache Maven packages
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
JIRA Ticket: GP-4550

#165 got hit with the actions brownout described in https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

CI passes like this

- [ ] Updates release notes
- [ ] Updates developer documentation

