### PR TITLE
Scan Illumina run directories in reverse order (which is approximately reverse chronological order)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ Changes:
 * Add consumables to Ultima Runs
 * Add "," to Ultima metrics (1000 -> 1,000) and reduce Total Beads to 6 decimal precision
 * Add "Control Sample Bases > Q30 %" Ultima metric
+* Update Illumina run directory scanning to be completed in reverse order by run directory name (approximately reverse chronological order)
 
 # 2.5.1
 

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/Scheduler.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/Scheduler.java
@@ -304,7 +304,11 @@ public class Scheduler {
   private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
   private UnreadableDirectories unreadableDirectories;
-  private final ExecutorService workPool = Executors.newWorkStealingPool();
+
+  // Executors.newFixedThreadPool uses a LinkedBlockingQueue by default for its work pool, which
+  // results in scanning jobs being executed in order of submission
+  private final ExecutorService workPool =
+      Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
 
   // The paths that need to be processed (and the corresponding processor).
   private final Set<File> workToDo = new ConcurrentSkipListSet<>();

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/DefaultIllumina.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/DefaultIllumina.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -248,7 +249,11 @@ public final class DefaultIllumina extends RunProcessor {
 
   @Override
   public Stream<File> getRunsFromRoot(File root) {
-    return Arrays.stream(root.listFiles(f -> f.isDirectory() && !f.getName().equals("Instrument")));
+    return Arrays.stream(
+            root.listFiles(f -> f.isDirectory() && !f.getName().equals("Instrument"))) //
+        // illumina runs start with yymmdd or yyyymmdd for newer instruments,
+        // we want runscanner to scan newer runs first
+        .sorted(Comparator.comparing(File::getName).reversed());
   }
 
   private boolean isLaneComplete(Path laneDir, IlluminaNotificationDto dto) {


### PR DESCRIPTION
I don't think we want to use directory last modified, as we perform run directory cleaning that will cause older run directories to be scanned ahead of newer run directories.

Change the workpool/runscanner job executor to a FixedThreadPool with a default LinkedBlockingQueue to ensure jobs get scanned in a FIFO basis (so the job execution order is in the same sort order of the Illumina run directories).

JIRA Ticket:

- [x] Updates release notes
- [ ] Updates developer documentation

