### PR TITLE
proper contianer model parsing for ultima (no func change)

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+Changes:
+* Handle Ulima container model parsing according to their naming conventions
+
 Fixes:
 * handle missing Ultima metrics without marking run as unreadable
 * return correct error response when deleting unreadable run

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 Changes:
-* Handle Ulima container model parsing according to their naming conventions
+* Handle Ultima container model parsing according to their naming conventions
 
 Fixes:
 * handle missing Ultima metrics without marking run as unreadable

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/DefaultUltima.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/DefaultUltima.java
@@ -18,8 +18,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -293,12 +291,9 @@ public class DefaultUltima extends RunProcessor {
   }
 
   private String extractModel(String serialNumber) throws IOException {
-    // Example: FC12.2T0123456789 -> FTC12.2T
-    Pattern pattern = Pattern.compile("^(.{4}\\..{2})");
-    Matcher matcher = pattern.matcher(serialNumber);
-    if (matcher.find()) {
-      // Group 1 contains the extracted text
-      return matcher.group(1);
+    // the last 10 characters are always to be removed
+    if (!serialNumber.isBlank()) {
+      return serialNumber.substring(0, serialNumber.length() - 10);
     } else {
       throw new IOException("Cannot determine container model from serial number: " + serialNumber);
     }

--- a/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/DefaultUltima.java
+++ b/scanner/src/main/java/ca/on/oicr/gsi/runscanner/scanner/processor/DefaultUltima.java
@@ -291,7 +291,7 @@ public class DefaultUltima extends RunProcessor {
   }
 
   private String extractModel(String serialNumber) throws IOException {
-    // the last 10 characters are always to be removed
+    // as per conversation with Ultima, the last 10 characters are always to be removed
     if (!serialNumber.isBlank()) {
       return serialNumber.substring(0, serialNumber.length() - 10);
     } else {


### PR DESCRIPTION
JIRA Ticket:

- [x] Updates release notes
- [ ] Updates developer documentation

Came out of meeting with Ultima about how the serial number is generated. Functionally no change now but there have been cases where FC12.2T0123456789 -> FTC12.2T and FC010123456789 -> FTC01 would have been correct
